### PR TITLE
Fixed Javascript error no function inside block

### DIFF
--- a/src/checkbox/styled-components.js
+++ b/src/checkbox/styled-components.js
@@ -276,7 +276,7 @@ export const Toggle = styled<SharedStylePropsT>('div', props => {
 export const ToggleInner = styled<SharedStylePropsT>('div', props => {
   if (props.$checkmarkType === STYLE_TYPE.toggle) {
     // eslint-disable-next-line no-inner-declarations
-    function backgroundColor() {
+    const backgroundColor = () => {
       if (props.$disabled) {
         return props.$theme.colors.sliderHandleInnerFillDisabled;
       }
@@ -290,7 +290,7 @@ export const ToggleInner = styled<SharedStylePropsT>('div', props => {
       }
 
       return props.$theme.colors.sliderHandleInnerFill;
-    }
+    };
     return {
       height: props.$theme.sizing.scale300,
       width: props.$theme.sizing.scale0,


### PR DESCRIPTION
In the compiled code, the ToggleInner function creates an if statement around the background function. In Javascript strict mode ("use strict") you can't create a function inside if statements. The function must be hoisted somehow or assigned to a block-scoped variable. 

Error reported: 

```
[19:44:51] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.
File: /home/ajbogh/Projects/superpac-ui/main.js
Line: 151408
Col: 4
```

Before:

```
var ToggleInner = (0, _index.styled)('div', function (props) {
  if (props.$checkmarkType === _constants.STYLE_TYPE.toggle) {
    // eslint-disable-next-line no-inner-declarations
    function backgroundColor() { // function inside if
```

After: 

```
var ToggleInner = (0, _index.styled)('div', function (props) {
  if (props.$checkmarkType === _constants.STYLE_TYPE.toggle) {
    // eslint-disable-next-line no-inner-declarations
    var backgroundColor = function () { // this works
```

`Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->

#### Description

<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
